### PR TITLE
chore(deps): upgrade to jsdoc v4 to resolve security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "gh-pages": "5.0.0",
         "git-authors-cli": "1.0.45",
         "husky": "7.0.4",
-        "jsdoc": "3.6.11",
+        "jsdoc": "4.0.2",
         "jsdom": "21.1.1",
         "jsdom-global": "3.0.2",
         "keycharm": "0.4.0",
@@ -2606,6 +2606,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
+      "integrity": "sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
       }
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
@@ -11150,12 +11162,13 @@
       }
     },
     "node_modules/jsdoc": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
-      "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
+      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.9.4",
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
         "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
@@ -11168,7 +11181,6 @@
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
-        "taffydb": "2.6.2",
         "underscore": "~1.13.2"
       },
       "bin": {
@@ -21583,12 +21595,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA==",
-      "dev": true
     },
     "node_modules/tar-fs": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gh-pages": "5.0.0",
     "git-authors-cli": "1.0.45",
     "husky": "7.0.4",
-    "jsdoc": "3.6.11",
+    "jsdoc": "4.0.2",
     "jsdom": "21.1.1",
     "jsdom-global": "3.0.2",
     "keycharm": "0.4.0",


### PR DESCRIPTION

chore(deps):upgrade to jsdoc v4
There is an open PR for this in visjs/vis-timeline, but the repo does not seem to have PRs reviewed very often. 